### PR TITLE
Add college team-level shot charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ You'll need to set up a Google BigQuery project in order to use College BallR. N
 
 ## Notes
 
-College BallR was hacked together fairly quickly from NBA BallR and should be considered experimental.
+College BallR supports shot charts by player and by team. It was hacked together fairly quickly from NBA BallR and should be considered experimental.
 
-The Sportradar BigQuery API is considerably more flexible than the NBA Stats API, which means that with more work, College BallR should be able to support shot charts by team, conference, mascot name, and many other dimensions. For now though it only supports shot charts by player.
+The Sportradar BigQuery API is considerably more flexible than the NBA Stats API, which is why College BallR supports team-level charts while the NBA version does not. With a bit more work, College BallR could support shot charts by conference, tournament, mascot name, and many other dimensions.
 
 ## Run your own local version
 
 You can run College BallR on your own machine by pasting the following code into the R console (you'll have to [install R](https://cran.rstudio.com/) first):
 
 ```R
-packages = c("shiny", "ggplot2", "hexbin", "dplyr", "httr", "jsonlite", "bigrquery", "lubridate")
+packages = c("shiny", "ggplot2", "hexbin", "dplyr", "httr", "jsonlite", "bigrquery", "lubridate", "readr")
 install.packages(packages, repos = "https://cran.rstudio.com/")
 library(shiny)
 runGitHub("ballr", "toddwschneider", ref = "college")
@@ -27,11 +27,11 @@ Enter your BigQuery credentials at the top of the sidebar. If it's your first ti
 
 There are three chart types to choose from: **hexagonal**, **scatter**, and **heat map**. Read more about them on [the NBA version's README page](https://github.com/toddwschneider/ballr).
 
-![college ballr](https://i.imgur.com/sHBQpPJ.png)
+![trae young college ballr](https://user-images.githubusercontent.com/70271/48303826-91cf7e00-e4dd-11e8-818e-001cbc2840f7.png)
 
-Team-level prototype (not available in app yet):
+Team-level:
 
-![villanova shot chart](https://i.imgur.com/eGW4NS9.png)
+![villanova shot chart](https://user-images.githubusercontent.com/70271/48303832-9d22a980-e4dd-11e8-8b1d-70c58cb8a5fc.png)
 
 ### Color themes
 

--- a/fetch_shots.R
+++ b/fetch_shots.R
@@ -1,5 +1,17 @@
 fetch_shots_by_player_id = function(player_id, bigquery_project_id) {
-  req(player_id, bigquery_project_id)
+  fetch_shots("player_id", player_id, bigquery_project_id)
+}
+
+fetch_shots_by_team_id = function(team_id, bigquery_project_id) {
+  fetch_shots("team_id", team_id, bigquery_project_id)
+}
+
+fetch_shots = function(column_name, column_value, bigquery_project_id) {
+  req(column_name, column_value, bigquery_project_id)
+
+  if (!(column_name %in% c("player_id", "team_id"))) {
+    stop("invalid column_name")
+  }
 
   shots_sql = paste0("
     SELECT
@@ -22,7 +34,7 @@ fetch_shots_by_player_id = function(player_id, bigquery_project_id) {
     WHERE type = 'fieldgoal'
       AND event_coord_x IS NOT NULL
       AND event_coord_y IS NOT NULL
-      AND player_id = '", player_id, "'
+      AND ", column_name, " = '", column_value, "'
   ")
 
   shots_raw = query_exec(shots_sql, bigquery_project_id) %>%

--- a/players_data.R
+++ b/players_data.R
@@ -1,27 +1,31 @@
 default_player_name = "Trae Young"
 
-fetch_all_players = function(bigquery_project_id) {
+fetch_all_players_and_teams = function(bigquery_project_id) {
   players_sql = "
     SELECT
       player_id,
       player_full_name,
       team_market,
-      team_name
+      team_name,
+      team_id,
+      team_alias,
+      MAX(timestamp) AS max_timestamp
     FROM [bigquery-public-data:ncaa_basketball.mbb_pbp_sr]
     WHERE type = 'fieldgoal'
       AND event_coord_x IS NOT NULL
       AND event_coord_y IS NOT NULL
-    GROUP BY player_id, player_full_name, team_market, team_name
+    GROUP BY player_id, player_full_name, team_market, team_name, team_id, team_alias
   "
 
   players_raw = query_exec(players_sql, bigquery_project_id) %>%
-    as_data_frame()
+    as_tibble() %>%
+    mutate(team_full_name = paste(team_market, team_name))
 
   players_with_unique_names = players_raw %>%
     group_by(player_full_name) %>%
     summarize(
       n = n_distinct(player_id),
-      team = paste0(paste(team_market, team_name), collapse = ", "),
+      team = paste0(team_full_name, collapse = ", "),
       player_id = first(player_id)
     ) %>%
     ungroup() %>%
@@ -33,7 +37,7 @@ fetch_all_players = function(bigquery_project_id) {
     transmute(
       player_id = player_id,
       player_full_name = paste0(player_full_name, " (", team_market, ")"),
-      team = paste(team_market, team_name)
+      team = team_full_name
     )
 
   players = bind_rows(players_with_unique_names, players_with_non_unique_names) %>%
@@ -47,5 +51,15 @@ fetch_all_players = function(bigquery_project_id) {
     mutate(lower_name = tolower(name)) %>%
     arrange(lower_name)
 
-  return(players)
+  teams = players_raw %>%
+    group_by(team_id, team_full_name) %>%
+    summarize(max_ts = max(max_timestamp)) %>%
+    arrange(team_id, desc(max_ts)) %>%
+    filter(row_number() == 1) %>%
+    ungroup() %>%
+    select(team_id, name = team_full_name) %>%
+    mutate(lower_name = tolower(name)) %>%
+    arrange(lower_name)
+
+  return(list(players = players, teams = teams))
 }

--- a/ui.R
+++ b/ui.R
@@ -61,8 +61,8 @@ shinyUI(
 
         div(class = "shot-chart-container",
           div(class = "shot-chart-header",
-            h2(textOutput("chart_header_player")),
-            h4(textOutput("chart_header_team")),
+            h2(textOutput("chart_header")),
+            h4(textOutput("chart_header_player_team")),
             h4(textOutput("chart_header_info"))
           ),
 
@@ -85,15 +85,12 @@ shinyUI(
         div(class = "shot-chart-inputs",
           textInput("bigquery_project_id", "BigQuery Project Name or ID"),
 
-          selectizeInput(inputId = "player_name",
-                        label = "Player",
-                        choices = c("Enter a player..." = "", default_player_name),
-                        selected = default_player_name,
-                        options = list(
-                          selectOnTab = TRUE,
-                          maxOptions = 20000,
-                          onDropdownOpen = I("function() { this.clear('silent'); }")
-                        )),
+          radioButtons(inputId = "view_shots_by",
+                       label = "View by",
+                       choices = c("Player", "Team"),
+                       selected = "Player"),
+
+          uiOutput("shots_select_input"),
 
           dateRangeInput(inputId = "date_range",
                          label = "Date range",

--- a/www/custom_styles.css
+++ b/www/custom_styles.css
@@ -7,11 +7,13 @@
   height: auto;
   margin-bottom: 20px;
 }
-#court_theme .radio {
+#court_theme .radio, #view_shots_by .radio {
   display: inline-block;
   padding-left: 0.5em;
 }
-#court_theme .shiny-options-group { display: inline-block; }
+#court_theme .shiny-options-group, #view_shots_by .shiny-options-group {
+  display: inline-block;
+}
 .shot-chart-container {
   position: relative;
   padding-bottom: 1em;


### PR DESCRIPTION
Add a radio button to toggle between player-level and team-level shot charts. Only supported in college edition due to flexibility of BigQuery API compared to NBA Stats API

![image](https://user-images.githubusercontent.com/70271/48319564-924f3e00-e5dd-11e8-8d52-0eb6abd6599e.png)

![image](https://user-images.githubusercontent.com/70271/48319569-9f6c2d00-e5dd-11e8-966b-06962a0643bb.png)

![image](https://user-images.githubusercontent.com/70271/48319544-4603fe00-e5dd-11e8-8425-8c7542986484.png)
