### PR TITLE
Fix error where left/right side of courts were flipped

### DIFF
--- a/fetch_shots.R
+++ b/fetch_shots.R
@@ -51,7 +51,7 @@ fetch_shots_by_player_id_and_season = function(player_id, season, season_type = 
     )
   }
 
-  shots = tbl_df(shots)
+  shots = as_tibble(shots)
   names(shots) = col_names
 
   shots = mutate(shots,

--- a/fetch_shots.R
+++ b/fetch_shots.R
@@ -55,7 +55,7 @@ fetch_shots_by_player_id_and_season = function(player_id, season, season_type = 
   names(shots) = col_names
 
   shots = mutate(shots,
-    loc_x = as.numeric(as.character(loc_x)) / 10,
+    loc_x = -as.numeric(as.character(loc_x)) / 10,
     loc_y = as.numeric(as.character(loc_y)) / 10 + hoop_center_y,
     shot_distance = as.numeric(as.character(shot_distance)),
     shot_made_numeric = as.numeric(as.character(shot_made_flag)),

--- a/hex_chart.R
+++ b/hex_chart.R
@@ -54,7 +54,7 @@ calculate_hex_coords = function(shots, binwidths) {
   hex_centers = hcell2xy(hb)
 
   hexbin_coords = bind_rows(lapply(1:hb@ncells, function(i) {
-    data_frame(
+    tibble(
       x = origin_coords$x + hex_centers$x[i],
       y = origin_coords$y + hex_centers$y[i],
       center_x = hex_centers$x[i],

--- a/plot_court.R
+++ b/plot_court.R
@@ -1,6 +1,6 @@
 circle_points = function(center = c(0, 0), radius = 1, npoints = 360) {
   angles = seq(0, 2 * pi, length.out = npoints)
-  return(data_frame(x = center[1] + radius * cos(angles),
+  return(tibble(x = center[1] + radius * cos(angles),
                     y = center[2] + radius * sin(angles)))
 }
 
@@ -24,25 +24,25 @@ plot_court = function(court_theme = court_themes$dark, use_short_three = FALSE) 
     three_point_side_height = 0
   }
 
-  court_points = data_frame(
+  court_points = tibble(
     x = c(width / 2, width / 2, -width / 2, -width / 2, width / 2),
     y = c(height, 0, 0, height, height),
     desc = "perimeter"
   )
 
-  court_points = bind_rows(court_points , data_frame(
+  court_points = bind_rows(court_points , tibble(
     x = c(outer_key_width / 2, outer_key_width / 2, -outer_key_width / 2, -outer_key_width / 2),
     y = c(0, key_height, key_height, 0),
     desc = "outer_key"
   ))
 
-  court_points = bind_rows(court_points , data_frame(
+  court_points = bind_rows(court_points , tibble(
     x = c(-backboard_width / 2, backboard_width / 2),
     y = c(backboard_offset, backboard_offset),
     desc = "backboard"
   ))
 
-  court_points = bind_rows(court_points , data_frame(
+  court_points = bind_rows(court_points , tibble(
     x = c(0, 0), y = c(backboard_offset, backboard_offset + neck_length), desc = "neck"
   ))
 
@@ -70,7 +70,7 @@ plot_court = function(court_theme = court_themes$dark, use_short_three = FALSE) 
   three_point_circle = circle_points(center = c(0, hoop_center_y), radius = three_point_radius) %>%
     filter(y >= three_point_side_height, y >= hoop_center_y)
 
-  three_point_line = data_frame(
+  three_point_line = tibble(
     x = c(three_point_side_radius, three_point_side_radius, three_point_circle$x, -three_point_side_radius, -three_point_side_radius),
     y = c(0, three_point_side_height, three_point_circle$y, three_point_side_height, 0),
     desc = "three_point_line"


### PR DESCRIPTION
Fixes https://github.com/toddwschneider/ballr/issues/16

Rather embarrassing bug, but it seems that I had been misinterpreting the `LOC_X` value returned by the NBA Stats API. Upon closer examination, it appears that `LOC_X` *should* behave as in this picture:

![marked_up_court](https://user-images.githubusercontent.com/70271/58292639-1570fe00-7d90-11e9-97e0-4f6ceb9cddef.png)

Confusing because positive values of `LOC_Y` work in the "normal" cartesian sense, but `LOC_X` is backwards